### PR TITLE
:recycle: remove compare dir name

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,16 +102,11 @@ Options:
 			return errors.Wrap(err, fmt.Sprintf("Can not read directory: %v, info: %v", dirName, info))
 		}
 
-		dir := filepath.Dir(path)
-		if dir != dirName {
-			return nil
-		}
-
 		if info.IsDir() {
 			return nil
 		}
 
-		fileName := filepath.Join(dir, info.Name())
+		fileName := filepath.Join(dirName, info.Name())
 		if contains(ignore, fileName) {
 			return nil
 		}


### PR DESCRIPTION
## What
remove if compare directory name to same value.

## Why
It is not necessary.
and difference both for command exec result `file-list example/ --ignore-list example/aaa.txt` and `file-list example --ignore-list example/aaa.txt`.

