### PR TITLE
:metal: append slash when prepare base dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ Options:
 		panic("Can not be shared option. --ignore and --only")
 	}
 
-	dirName := os.Args[1]
+	dirName := filepath.Dir(os.Args[1] + "/")
 
 	var files []string
 	err := filepath.Walk(dirName, func(path string, info os.FileInfo, err error) error {
@@ -103,6 +103,11 @@ Options:
 		}
 
 		if info.IsDir() {
+			return nil
+		}
+
+		dir := filepath.Dir(path)
+		if dir != dirName {
 			return nil
 		}
 


### PR DESCRIPTION
## What

When decided base dirname, append slash everytime.
And skip diferrence dir name path.

## Why
reference: #3 

run file-list, but output to missing directory level. So, example/eee.txt is missing. `eee.txt` is exits `example/hoge/eee.txt`. 

```
$ file-list example --ignore-with-file example/files.txt
example/bbb.txt
example/ccc.txt
example/ddd.txt
example/files.txt
example/eee.txt
```